### PR TITLE
feat: 增加 redis的序列化配置

### DIFF
--- a/dice-server/pom.xml
+++ b/dice-server/pom.xml
@@ -108,6 +108,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.alibaba/fastjson -->
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.60</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/dice-server/src/main/java/com/bihell/dice/config/RedisConfig.java
+++ b/dice-server/src/main/java/com/bihell/dice/config/RedisConfig.java
@@ -1,10 +1,15 @@
 package com.bihell.dice.config;
 
+import com.alibaba.fastjson.support.spring.FastJsonRedisSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.lang.reflect.Method;
 
@@ -15,6 +20,28 @@ import java.lang.reflect.Method;
 @Configuration
 @EnableCaching
 public class RedisConfig extends CachingConfigurerSupport {
+
+    private final RedisTemplate redisTemplate;
+
+    @Autowired
+    public RedisConfig(RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisSerializer<String> stringSerializer = new StringRedisSerializer();
+        //RedisSerializer<Object> jsonString = new GenericToStringSerializer<>(Object.class);
+        RedisSerializer<Object> jsonString = new FastJsonRedisSerializer<>(Object.class);
+        // String 的 key 和 hash 的 key 都采用 String 的序列化方式
+        redisTemplate.setKeySerializer(stringSerializer);
+        redisTemplate.setHashKeySerializer(stringSerializer);
+        // value 都采用 fastjson 的序列化方式
+        redisTemplate.setValueSerializer(jsonString);
+        redisTemplate.setHashValueSerializer(jsonString);
+        return redisTemplate;
+    }
 
     @Override
     @Bean

--- a/dice-server/src/test/java/com/bihell/dice/redis/RedisApplicationTests.java
+++ b/dice-server/src/test/java/com/bihell/dice/redis/RedisApplicationTests.java
@@ -1,0 +1,37 @@
+package com.bihell.dice.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Slf4j
+public class RedisApplicationTests {
+
+    @Autowired
+    RedisTemplate redisTemplate;
+
+    private final static String USERKEY = "username";
+    private final static String AGEKEY = "age";
+    private final static String CITYKEY = "city";
+
+    private final static String LISTKEY = "studentList";
+    private final static String SETKEY = "usernameSet";
+    private final static String HASHKEY = "studentHash";
+
+    /**
+     * 添加字符串
+     */
+    @Test
+    public void setString() {
+        redisTemplate.opsForValue().set(USERKEY, "nasus");
+        redisTemplate.opsForValue().set(AGEKEY, 24);
+        redisTemplate.opsForValue().set(CITYKEY, "清远");
+    }
+
+}


### PR DESCRIPTION
 SpringBoot 自动配置的这个 RedisTemplate 是没有设置数据读取时的 key 及 value 的序列化方式的。所以，我们要写一个自己的 RedisTemplate 并设置 key 及 value 的序列化方式才可以正常操作 Redis。